### PR TITLE
ci(mono-pub): run publish job from LTS node

### DIFF
--- a/.github/workflows/nodejs.packages.ci.yml
+++ b/.github/workflows/nodejs.packages.ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4

--- a/.github/workflows/nodejs.packages.debug.yml
+++ b/.github/workflows/nodejs.packages.debug.yml
@@ -1,0 +1,36 @@
+name: Publish NPM packages
+
+permissions:
+  contents: write
+  id-token: write
+
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+        # NOTE: Mono-pub uses itself to publish its packages, so we need to prebuild them
+      - name: Build packages
+        run: yarn build
+
+      - name: Debug 1
+        run: |
+          git tag --merged

--- a/.github/workflows/nodejs.packages.debug.yml
+++ b/.github/workflows/nodejs.packages.debug.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for automating the publishing of NPM packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->