### PR TITLE
feat(mono-pub)!: ADR-1 split prepare into prepareAll and prepareSingle

### DIFF
--- a/bin/publish.js
+++ b/bin/publish.js
@@ -12,7 +12,7 @@ const builder = {
     async prepareAll({ foundPackages }, ctx) {
         const batches = getExecutionOrder(foundPackages, { batching: true })
         for (const batch of batches) {
-            await execa('yarn', ['build', batch.map((pkg) => `--filter=${pkg.name}`)], { cwd: ctx.cwd })
+            await execa('yarn', ['build', ...batch.map((pkg) => `--filter=${pkg.name}`)], { cwd: ctx.cwd })
         }
     },
 }

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -4,11 +4,16 @@ const git = require('@mono-pub/git')
 const github = require('@mono-pub/github')
 const npm = require('@mono-pub/npm')
 const commitAnalyzer = require('@mono-pub/commit-analyzer')
+const { getExecutionOrder } = require('mono-pub/utils')
 
+/** @type {import('mono-pub').MonoPubPlugin} */
 const builder = {
     name: '@mono-pub/local-builder',
-    async prepare(_, ctx) {
-        await execa('yarn', ['build'], { cwd: ctx.cwd })
+    async prepareAll({ foundPackages }, ctx) {
+        const batches = getExecutionOrder(foundPackages, { batching: true })
+        for (const batch of batches) {
+            await execa('yarn', ['build', batch.map((pkg) => `--filter=${pkg.name}`)], { cwd: ctx.cwd })
+        }
     },
 }
 

--- a/packages/mono-pub/README.md
+++ b/packages/mono-pub/README.md
@@ -163,7 +163,7 @@ const git = require('@mono-pub/git')
 const github = require('@mono-pub/github')
 const npm = require('@mono-pub/npm')
 const commitAnalyzer = require('@mono-pub/commit-analyzer')
-const {} = require()
+const { getExecutionOrder } = require('mono-pub/utils')
 
 /** @type {import('mono-pub').MonoPubPlugin} */
 const builder = {
@@ -171,7 +171,7 @@ const builder = {
     async prepareAll({ foundPackages }, ctx) {
         const batches = getExecutionOrder(foundPackages, { batching: true })
         for (const batch of batches) {
-            await execa('yarn', ['build', batch.map(pkg => `--filter=${pkg.name}`)], { cwd: ctx.cwd })
+            await execa('yarn', ['build', ...batch.map(pkg => `--filter=${pkg.name}`)], { cwd: ctx.cwd })
         }
     },
 }

--- a/packages/mono-pub/src/types/plugins.ts
+++ b/packages/mono-pub/src/types/plugins.ts
@@ -19,7 +19,7 @@ export type PrepareAllInfo = {
 }
 
 export type PrepareSingleInfo = PrepareAllInfo & {
-    package: BasePackageInfo
+    targetPackage: BasePackageInfo
 }
 
 export interface MonoPubPlugin {

--- a/packages/mono-pub/src/utils/deps.spec.ts
+++ b/packages/mono-pub/src/utils/deps.spec.ts
@@ -133,7 +133,7 @@ describe('Dependencies utils', () => {
     describe('getExecutionOrder', () => {
         it('Should determine release order from leafs to root of deps tree', async () => {
             const deps = await getDependencies([pkg3Info, pkg2Info, pkg1Info])
-            const order = getExecutionOrder(deps)
+            const order = getExecutionOrder(Object.values(deps))
             expect(order).toEqual([pkg1Info, pkg2Info, pkg3Info])
         })
         it('Should throw if cyclic deps found', async () => {
@@ -141,12 +141,12 @@ describe('Dependencies utils', () => {
             deps[pkg1Info.name].dependsOn.push({ name: pkg3Info.name, value: '1.0.0', type: 'dep' })
 
             expect(() => {
-                getExecutionOrder(deps)
+                getExecutionOrder(Object.values(deps))
             }).toThrow('The release cannot be done because of cyclic dependencies')
         })
         it('Can batch tasks, which can be executed together', async () => {
             const deps = await getDependencies([pkg3Info, pkg2Info, pkg1Info, pkg4Info])
-            const batches = getExecutionOrder(deps, { batching: true })
+            const batches = getExecutionOrder(Object.values(deps), { batching: true })
             expect(batches).toEqual([[pkg1Info, pkg4Info], [pkg2Info], [pkg3Info]])
         })
     })

--- a/packages/mono-pub/src/utils/deps.spec.ts
+++ b/packages/mono-pub/src/utils/deps.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { dirSync } from 'tmp'
 import { faker } from '@faker-js/faker'
-import { getDependencies, getReleaseOrder, patchPackageDeps } from './deps'
+import { getDependencies, getExecutionOrder, patchPackageDeps } from './deps'
 import { getNewVersion, versionToString } from './versions'
 
 import type { DirResult } from 'tmp'
@@ -28,6 +28,7 @@ describe('Dependencies utils', () => {
     let pkg1Info: BasePackageInfo
     let pkg2Info: BasePackageInfo
     let pkg3Info: BasePackageInfo
+    let pkg4Info: BasePackageInfo
     beforeEach(() => {
         tmpDir = dirSync({ unsafeCleanup: true })
         pkg1Info = {
@@ -43,7 +44,13 @@ describe('Dependencies utils', () => {
             location: path.join(tmpDir.name, 'packages/pkg3', 'package.json'),
         }
 
+        pkg4Info = {
+            name: '@scope/pkg4',
+            location: path.join(tmpDir.name, 'packages/pkg4', 'package.json'),
+        }
+
         writePackageJson({ name: pkg1Info.name, version: '0.0.0-development' }, 'packages/pkg1', tmpDir.name)
+        writePackageJson({ name: pkg4Info.name, version: '0.0.0-development' }, 'packages/pkg4', tmpDir.name)
         writePackageJson(
             {
                 name: pkg2Info.name,
@@ -78,11 +85,15 @@ describe('Dependencies utils', () => {
     })
     describe('getDependencies', () => {
         it('Should determine deps of packages correctly', async () => {
-            const deps = await getDependencies([pkg1Info, pkg2Info, pkg3Info])
+            const deps = await getDependencies([pkg1Info, pkg2Info, pkg3Info, pkg4Info])
             expect(deps).toEqual(
                 expect.objectContaining({
                     [pkg1Info.name]: {
                         ...pkg1Info,
+                        dependsOn: [],
+                    },
+                    [pkg4Info.name]: {
+                        ...pkg4Info,
                         dependsOn: [],
                     },
                     [pkg2Info.name]: {
@@ -99,6 +110,7 @@ describe('Dependencies utils', () => {
                 })
             )
             expect(deps[pkg1Info.name].dependsOn).toHaveLength(0)
+            expect(deps[pkg4Info.name].dependsOn).toHaveLength(0)
             expect(deps[pkg2Info.name].dependsOn).toHaveLength(1)
             expect(deps[pkg3Info.name].dependsOn).toHaveLength(2)
         })
@@ -118,19 +130,24 @@ describe('Dependencies utils', () => {
             )
         })
     })
-    describe('getReleaseOrder', () => {
+    describe('getExecutionOrder', () => {
         it('Should determine release order from leafs to root of deps tree', async () => {
             const deps = await getDependencies([pkg3Info, pkg2Info, pkg1Info])
-            const order = getReleaseOrder(deps)
-            expect(order).toEqual([pkg1Info.name, pkg2Info.name, pkg3Info.name])
+            const order = getExecutionOrder(deps)
+            expect(order).toEqual([pkg1Info, pkg2Info, pkg3Info])
         })
         it('Should throw if cyclic deps found', async () => {
             const deps = await getDependencies([pkg3Info, pkg2Info, pkg1Info])
             deps[pkg1Info.name].dependsOn.push({ name: pkg3Info.name, value: '1.0.0', type: 'dep' })
 
             expect(() => {
-                getReleaseOrder(deps)
+                getExecutionOrder(deps)
             }).toThrow('The release cannot be done because of cyclic dependencies')
+        })
+        it('Can batch tasks, which can be executed together', async () => {
+            const deps = await getDependencies([pkg3Info, pkg2Info, pkg1Info, pkg4Info])
+            const batches = getExecutionOrder(deps, { batching: true })
+            expect(batches).toEqual([[pkg1Info, pkg4Info], [pkg2Info], [pkg3Info]])
         })
     })
     describe('patchPackageDeps', () => {

--- a/packages/mono-pub/src/utils/deps.ts
+++ b/packages/mono-pub/src/utils/deps.ts
@@ -34,39 +34,56 @@ export async function getDependencies(
     return result
 }
 
-export function getReleaseOrder(packages: Record<string, PackageInfoWithDependencies>): Array<string> {
-    const order: Array<string> = []
+type ExecutionOrder<T extends boolean | undefined> = T extends true
+    ? Array<Array<BasePackageInfo>>
+    : Array<BasePackageInfo>
 
-    const deps = new Map<string, Array<string>>()
+type TaskPlanningOptions<T extends boolean | undefined> = {
+    batching?: T
+}
+
+export function getExecutionOrder<T extends boolean | undefined = undefined>(
+    packages: Record<string, PackageInfoWithDependencies>,
+    options?: TaskPlanningOptions<T>
+): ExecutionOrder<T> {
+    const batches: Array<Array<BasePackageInfo>> = []
+
+    const dependencies = new Map<keyof typeof packages, Array<string>>()
     for (const pkg of Object.values(packages)) {
-        deps.set(
+        dependencies.set(
             pkg.name,
             pkg.dependsOn.map((dep) => dep.name)
         )
     }
 
-    while (deps.size > 0) {
-        const toRelease: Array<string> = []
-        for (const [key, value] of deps) {
-            if (value.length === 0) {
-                toRelease.push(key)
-                deps.delete(key)
+    while (dependencies.size > 0) {
+        const batch: Array<BasePackageInfo> = []
+        for (const [pkgName, pkgDeps] of dependencies) {
+            if (pkgDeps.length === 0) {
+                batch.push({ name: pkgName, location: packages[pkgName].location })
+                dependencies.delete(pkgName)
             }
         }
-        if (toRelease.length === 0) {
+
+        if (batch.length === 0) {
             throw new Error('The release cannot be done because of cyclic dependencies')
-        } else {
-            order.push(...toRelease)
-            for (const [key, value] of deps) {
-                deps.set(
-                    key,
-                    value.filter((pkg) => !toRelease.includes(pkg))
-                )
-            }
+        }
+
+        batches.push(batch)
+        const includedPackages = batch.map((pkg) => pkg.name)
+        for (const [pkgName, pkgDeps] of dependencies) {
+            dependencies.set(
+                pkgName,
+                pkgDeps.filter((depName) => !includedPackages.includes(depName))
+            )
         }
     }
 
-    return order
+    if (options?.batching) {
+        return batches as ExecutionOrder<T>
+    }
+
+    return batches.flat() as ExecutionOrder<T>
 }
 
 export async function patchPackageDeps(

--- a/packages/mono-pub/src/utils/deps.ts
+++ b/packages/mono-pub/src/utils/deps.ts
@@ -43,13 +43,14 @@ type TaskPlanningOptions<T extends boolean | undefined> = {
 }
 
 export function getExecutionOrder<T extends boolean | undefined = undefined>(
-    packages: Record<string, PackageInfoWithDependencies>,
+    packages: Array<PackageInfoWithDependencies>,
     options?: TaskPlanningOptions<T>
 ): ExecutionOrder<T> {
     const batches: Array<Array<BasePackageInfo>> = []
+    const pkgMap = Object.fromEntries(packages.map((pkg) => [pkg.name, pkg]))
 
-    const dependencies = new Map<keyof typeof packages, Array<string>>()
-    for (const pkg of Object.values(packages)) {
+    const dependencies = new Map<string, Array<string>>()
+    for (const pkg of packages) {
         dependencies.set(
             pkg.name,
             pkg.dependsOn.map((dep) => dep.name)
@@ -60,7 +61,7 @@ export function getExecutionOrder<T extends boolean | undefined = undefined>(
         const batch: Array<BasePackageInfo> = []
         for (const [pkgName, pkgDeps] of dependencies) {
             if (pkgDeps.length === 0) {
-                batch.push({ name: pkgName, location: packages[pkgName].location })
+                batch.push({ name: pkgName, location: pkgMap[pkgName].location })
                 dependencies.delete(pkgName)
             }
         }

--- a/packages/mono-pub/src/utils/index.ts
+++ b/packages/mono-pub/src/utils/index.ts
@@ -1,1 +1,2 @@
+export { getExecutionOrder } from './deps'
 export { versionToString } from './versions'

--- a/packages/mono-pub/src/utils/plugins.spec.ts
+++ b/packages/mono-pub/src/utils/plugins.spec.ts
@@ -193,6 +193,9 @@ describe('CombinedPlugin', () => {
             },
         }
     })
+    afterEach(() => {
+        tmpDir.removeCallback()
+    })
     describe('Setup', () => {
         it('Should setup all plugins in setup stage', async () => {
             const combined = new CombinedPlugin([chain.getter, chain.extractor, chain.analyzer])

--- a/packages/mono-pub/src/utils/plugins.ts
+++ b/packages/mono-pub/src/utils/plugins.ts
@@ -164,7 +164,7 @@ export class CombinedPlugin implements MonoPubPlugin {
                     const scopedContext = { ...ctx, logger: scopedLogger }
 
                     scopedLogger.log(`Running "prepareSingle" step of "${plugin.name}" plugin`)
-                    await plugin.prepareSingle({ ...info, package: pkg }, scopedContext)
+                    await plugin.prepareSingle({ ...info, targetPackage: pkg }, scopedContext)
                 }
             }
         }

--- a/packages/mono-pub/src/utils/plugins.ts
+++ b/packages/mono-pub/src/utils/plugins.ts
@@ -1,3 +1,5 @@
+import { getExecutionOrder } from '@/utils'
+
 import type {
     MonoPubPlugin,
     MonoPubContext,
@@ -7,6 +9,7 @@ import type {
     ReleaseType,
     CommitInfo,
     ReleasedPackageInfo,
+    PrepareAllInfo,
 } from '@/types'
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
@@ -14,7 +17,7 @@ type WithSetup = WithRequired<MonoPubPlugin, 'setup'>
 type WithGetLastRelease = WithRequired<MonoPubPlugin, 'getLastRelease'>
 type WithExtractor = WithRequired<MonoPubPlugin, 'extractCommits'>
 type WithAnalyzer = WithRequired<MonoPubPlugin, 'getReleaseType'>
-type WithPrepare = WithRequired<MonoPubPlugin, 'prepare'>
+type WithPrepare = WithRequired<MonoPubPlugin, 'prepareAll'> | WithRequired<MonoPubPlugin, 'prepareSingle'>
 type WithPublish = WithRequired<MonoPubPlugin, 'publish'>
 type WithPostPublish = WithRequired<MonoPubPlugin, 'postPublish'>
 
@@ -66,8 +69,17 @@ export class CombinedPlugin implements MonoPubPlugin {
                 this.analyzer = plugin as WithAnalyzer
             }
 
-            if (plugin.prepare) {
-                logger.log(this._getStepMessage('prepare', plugin))
+            if (plugin.prepareAll || plugin.prepareSingle) {
+                if (plugin.prepareAll && plugin.prepareSingle) {
+                    logger.warn(
+                        `Plugin "${plugin.name}" implements both "prepareAll" and "prepareSingle" methods, so only "prepareAll" be executed`
+                    )
+                } else if (plugin.prepareAll) {
+                    logger.info(this._getStepMessage('prepareAll', plugin))
+                } else {
+                    logger.info(this._getStepMessage('prepareSingle', plugin))
+                }
+
                 this.preparers.push(plugin as WithPrepare)
             }
 
@@ -139,10 +151,22 @@ export class CombinedPlugin implements MonoPubPlugin {
         return this.analyzer.getReleaseType(commits, isDepsChanged, ctx)
     }
 
-    async prepare(packages: Array<BasePackageInfo>, ctx: MonoPubContext): Promise<void> {
+    async prepareAll(info: PrepareAllInfo, ctx: MonoPubContext): Promise<void> {
+        const executionOrder = getExecutionOrder(info.foundPackages)
+
         for (const plugin of this.preparers) {
-            ctx.logger.log(`Running "prepare" step of "${plugin.name}" plugin`)
-            await plugin.prepare(packages, ctx)
+            if (plugin.prepareAll) {
+                ctx.logger.log(`Running "prepareAll" step of "${plugin.name}" plugin`)
+                await plugin.prepareAll(info, ctx)
+            } else if (plugin.prepareSingle) {
+                for (const pkg of executionOrder) {
+                    const scopedLogger = ctx.logger.scope(pkg.name)
+                    const scopedContext = { ...ctx, logger: scopedLogger }
+
+                    scopedLogger.log(`Running "prepareSingle" step of "${plugin.name}" plugin`)
+                    await plugin.prepareSingle({ ...info, package: pkg }, scopedContext)
+                }
+            }
         }
     }
 

--- a/packages/mono-pub/src/utils/versions.ts
+++ b/packages/mono-pub/src/utils/versions.ts
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual'
 import type { LatestReleasedVersion, ReleaseType, PackageVersion } from '@/types'
 
 const PATCH_REGEX = /\d+.\d+.x/i
@@ -29,4 +30,12 @@ export function getVersionCriteria(currentVersion: string, newVersion: string) {
         return `^${newVersion}`
     }
     return newVersion
+}
+
+export function isPackageChanged(
+    newVersion: LatestReleasedVersion,
+    oldVersion: LatestReleasedVersion,
+    releaseType: ReleaseType
+): newVersion is NonNullable<PackageVersion> {
+    return !(releaseType === 'none' || !newVersion || isEqual(newVersion, oldVersion))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function `isPackageChanged` for enhanced version change detection.
	- Added `prepareAll` and `prepareSingle` methods for improved package preparation processes.
	- Added `getExecutionOrder` function to manage package execution order with batching capabilities.
	- Enhanced the `README.md` with updated plugin examples and detailed publishing workflow.

- **Bug Fixes**
	- Enhanced error handling for cyclic dependencies during package execution order determination.

- **Documentation**
	- Updated comments and method signatures for clarity regarding the new preparation and execution processes.
	- Refined documentation to clarify the publishing workflow and post-publish actions.

- **Tests**
	- Expanded test cases to include new functionalities and ensure proper validation of dependency management.
	- Improved setup for testing framework to accommodate new methods and structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->